### PR TITLE
Revert tool symlinks branch

### DIFF
--- a/server/code/index.coffee
+++ b/server/code/index.coffee
@@ -547,6 +547,10 @@ postTool = (req, resp) ->
         public: publicBool
     else
       _.extend tool, body
+    # Start updating the tool instances (datasets and views)
+    console.log "Starting to update tool instances..."
+    tool.updateInstances (err, res) ->
+      console.log "Finished updating tool instances. #{err} #{res}"
     tool.gitCloneOrPull dir: process.env.CU_TOOLS_DIR, (err, stdout, stderr) ->
       console.log err, stdout, stderr
       if err?

--- a/server/code/model/box.coffee
+++ b/server/code/model/box.coffee
@@ -1,4 +1,3 @@
-_ = require 'underscore'
 mongoose = require 'mongoose'
 async = require 'async'
 nibbler = require 'nibbler'
@@ -9,7 +8,6 @@ Schema = mongoose.Schema
 ModelBase = require 'model/base'
 {Tool} = require 'model/tool'
 {Plan} = require 'model/plan'
-plans = require 'plans.json'
 
 boxSchema = new Schema
   users: [String]
@@ -62,8 +60,9 @@ class Box extends ModelBase
             user: arg.user
             boxName: @name
             boxServer: @server
-            #TODO(ehg): don't create http dir in cobalt
-            cmd: "rm -fr http ; mkdir incoming ; ln -s /tools/#{tool.name} tool ; ln -s tool/http http"
+            # :todo: we don't really need to remove the http directory any more,
+            # because cobalt no longer furnishes it.
+            cmd: "rm -fr http ; mkdir incoming ; git clone #{gitURL} --depth 1 tool ; ln -s tool/http http"
           , (err, res, body) ->
             if err?
               callback err
@@ -167,12 +166,6 @@ class Box extends ModelBase
     max = 429496729
     min = 4000
     Math.floor(Math.random() * (max - min + 1)) + min
-
-  @listServers: ->
-    if /staging/.test process.env.NODE_ENV
-      return [process.env.CU_BOX_SERVER]
-    _.uniq (obj.boxServer for plan, obj of plans)
-
 
 exports.Box = Box
 

--- a/server/code/model/plan.coffee
+++ b/server/code/model/plan.coffee
@@ -1,4 +1,3 @@
-_ = require 'underscore'
 request = require 'request'
 plans = require 'plans.json'
 
@@ -25,6 +24,5 @@ class exports.Plan
       return ["Plan #{planName} not found", null]
     else
       if process.env.CU_BOX_SERVER
-        plan = _.clone(plan)
         plan.boxServer = process.env.CU_BOX_SERVER
       return [null, plan]

--- a/server/code/plans.json
+++ b/server/code/plans.json
@@ -1,4 +1,11 @@
 {
+    "dataservices": {
+        "boxServer": "ds.scraperwiki.com",
+        "maxDiskSpaceMB": 4000,
+        "maxHourCPUPerDay": 2.0,
+        "maxNumDatasets": 81,
+        "$": true
+    },
     "dataservices-ec2": {
         "boxServer": "ds-ec2.scraperwiki.com",
         "maxDiskSpaceMB": 4000,
@@ -13,6 +20,13 @@
         "maxNumDatasets": 3,
         "$": false
     },
+    "grandfather": {
+        "boxServer": "box.scraperwiki.com",
+        "maxDiskSpaceMB": 8000,
+        "maxHourCPUPerDay": 0.5,
+        "maxNumDatasets": 100,
+        "$": false
+    },
     "grandfather-ec2": {
         "boxServer": "premium.scraperwiki.com",
         "maxDiskSpaceMB": 8000,
@@ -20,11 +34,25 @@
         "maxNumDatasets": 100,
         "$": false
     },
+    "large": {
+        "boxServer": "box.scraperwiki.com",
+        "maxDiskSpaceMB": 256,
+        "maxHourCPUPerDay": 0.5,
+        "maxNumDatasets": 81,
+        "$": true
+    },
     "large-ec2": {
         "boxServer": "premium.scraperwiki.com",
         "maxDiskSpaceMB": 256,
         "maxHourCPUPerDay": 0.5,
         "maxNumDatasets": 81,
+        "$": true
+    },
+    "medium": {
+        "boxServer": "box.scraperwiki.com",
+        "maxDiskSpaceMB": 64,
+        "maxHourCPUPerDay": 0.5,
+        "maxNumDatasets": 10,
         "$": true
     },
     "medium-ec2": {

--- a/test/unit/model/box.coffee
+++ b/test/unit/model/box.coffee
@@ -19,7 +19,7 @@ describe 'Box (server)', ->
     before (done) ->
       Box.create
         shortName: 'testofferson'
-        accountLevel: 'grandfather-ec2'
+        accountLevel: 'grandfather'
       , (err, box) =>
         firstBox = box
         done err
@@ -44,7 +44,7 @@ describe 'Box (server)', ->
 
       Box.create
         shortName: 'testofferson'
-        accountLevel: 'grandfather-ec2'
+        accountLevel: 'grandfather'
       , (err, box) =>
         @secondBox = box
         done()
@@ -68,14 +68,3 @@ describe 'Box (server)', ->
 
     it "doesn't change its uid", ->
       @sameBox.uid.should.equal firstBox.uid
-
-  context 'when I call Box.listServers', ->
-    before -> @servers = Box.listServers()
-
-    it 'returns an array of all the box servers', ->
-      @servers.should.include 'premium.scraperwiki.com'
-      @servers.should.include 'free-ec2.scraperwiki.com'
-      @servers.should.include 'ds-ec2.scraperwiki.com'
-
-    it 'gives me three servers (because that is how many there currently are)', ->
-      @servers.length.should.equal 3

--- a/test/unit/model/serv_tool.coffee
+++ b/test/unit/model/serv_tool.coffee
@@ -63,15 +63,8 @@ describe 'Server model: Tool', ->
         @tool = new Tool name: 'test'
         @tool.gitCloneOrPull dir: "test/tmp/repos", done
 
-      it 'should make a directory for the repository', ->
-        @exec.firstCall.calledWithMatch(/^mkdir/).should.be.true
-      it 'should git init and fetch a repository', ->
-        @exec.firstCall.calledWithMatch(/git init; git fetch .*; git checkout FETCH_HEAD/).should.be.true
-
-      it 'should rsync the tool to all box servers', ->
-        @exec.calledWithMatch(/^run-this-one rsync .* \/opt\/tools\/ .*premium/).should.be.true
-        @exec.calledWithMatch(/^run-this-one rsync .* \/opt\/tools\/ .*free-ec2/).should.be.true
-        @exec.calledWithMatch(/^run-this-one rsync .* \/opt\/tools\/ .*ds-ec2/).should.be.true
+      it 'should git clone a directory', ->
+        @exec.calledWithMatch(/^git clone/).should.be.true
 
       before (done) ->
         @spy = sinon.spy JSON, 'parse'
@@ -112,13 +105,8 @@ describe 'Server model: Tool', ->
         @tool = new Tool name: 'test'
         @tool.gitCloneOrPull dir: "test/tmp/repos", done
 
-      it 'should rsync the tool to all box servers', ->
-        @exec.calledWithMatch(/^run-this-one rsync .* \/opt\/tools\/ .*premium/).should.be.true
-        @exec.calledWithMatch(/^run-this-one rsync .* \/opt\/tools\/ .*free-ec2/).should.be.true
-        @exec.calledWithMatch(/^run-this-one rsync .* \/opt\/tools\/ .*ds-ec2/).should.be.true
-   
-      it 'should fetch the contents of the repository from upstream and check it out', ->
-        @exec.calledWithMatch(/git fetch .*; git checkout FETCH_HEAD/).should.be.true
+      it 'should run a git pull', ->
+        @exec.calledWithMatch(/git pull/).should.be.true
 
       before (done) ->
         @fsRead = sinon.stub fs, 'readFile', (path_, cb) ->
@@ -146,3 +134,37 @@ describe 'Server model: Tool', ->
 
       it 'should have a gitUrl', ->
         should.exist @tool.manifest.gitUrl
+
+  context 'An "importer" tool: when tool.updateInstances is called', ->
+    before (done) ->
+      @requestStub = sinon.stub(request, 'post').callsArg(1)
+      Tool.findOneByName 'spreadsheet-upload', (err, tool) =>
+        tool.updateInstances done
+
+    it 'has updated the dataset boxes', ->
+      pulledInDSBox = @requestStub.calledWith
+        uri: sinon.match /2416349265/
+        form:
+          apikey: 'zarino'
+          cmd: sinon.match /git pull/
+      pulledInDSBox.should.be.true
+
+    after ->
+      request.post.restore()
+
+  xcontext 'A "view" tool: when tool.updateInstances is called', ->
+    before (done) ->
+      @requestStub = sinon.stub(request, 'post').callsArg(1)
+      Tool.findOneByName 'test-plugin', (err, tool) =>
+        tool.updateInstances done
+
+    it 'has updated the view boxes', ->
+      pulledInViewBox = @requestStub.calledWithMatch
+        uri: sinon.match /4008115731/
+        form:
+          apikey: sinon.match new RegExp(process.env.COTEST_USER_API_KEY)
+          cmd: sinon.match /git pull/
+      pulledInViewBox.should.be.true
+
+    after ->
+      request.post.restore()


### PR DESCRIPTION
Revert "Merge pull request #360 from scraperwiki/20130816-tool-symlinks"

This reverts commit 5089bffb018cdf2db76f6e0f343effc190889e94, reversing 
changes made to 357ab18bdb7d740e2a3fb51325d4fc7e45a2f4cc.

This broke the magic table scraper, amongst others, because they write to
the tool directory (which they're not able to when it's a symlink to a read
-only file system)

To re-merge when we're ready, this commit should be reverted, and then
the branch can be re-merged with whatever additional changes it has.
