### PR TITLE
Another tweak to the scraperwiki.reporting.message() API

### DIFF
--- a/client/code/view/tool/content.coffee
+++ b/client/code/view/tool/content.coffee
@@ -85,22 +85,14 @@ class Cu.View.ToolContent extends Backbone.View
               displayName: window.user.effective.displayName
               email: window.user.effective.email[0]
         reportingMessage: (message, success, error) ->
-          dfd = new jQuery.Deferred()
           $.ajax
             type: 'POST'
             url: '/api/reporting/message/'
             data:
               url: window.location.href
               message: message
-            success: ->
-              if typeof(success) is 'function'
-                success()
-              dfd.resolve()
-            error: ->
-              if typeof(error) is 'function'
-                error()
-              dfd.reject()
-          return dfd.promise()
+            success: success
+            error: error
 
 
 class Cu.View.AppContent extends Cu.View.ToolContent

--- a/shared/code/scraperwiki.coffee
+++ b/shared/code/scraperwiki.coffee
@@ -256,7 +256,12 @@ scraperwiki.reporting.message = (message, success, error) ->
   ###
   Send a message from the current user to Intercom, our reporting package
   ###
-  return parent.scraperwiki.xdm.reportingMessage message, success, error
+  dfd = new jQuery.Deferred()
+  dfd.done(success)
+  dfd.fail(error)
+
+  parent.scraperwiki.xdm.reportingMessage message, dfd.resolve, dfd.reject
+  return dfd.promise()
 
 
 # HERE BE DEPRECATED FUNCTIONS:


### PR DESCRIPTION
seems you can't return from an xdm call, so use callbacks instead
