### PR TITLE
handle the cases where success and error callbacks are not provided…

### DIFF
--- a/client/code/view/tool/content.coffee
+++ b/client/code/view/tool/content.coffee
@@ -91,8 +91,12 @@ class Cu.View.ToolContent extends Backbone.View
             data:
               url: window.location.href
               message: message
-            success: success
-            error: error
+            success: ->
+              if typeof success is 'function'
+                success()
+            error: ->
+              if typeof error is 'function'
+                error()
 
 
 class Cu.View.AppContent extends Cu.View.ToolContent

--- a/shared/code/scraperwiki.coffee
+++ b/shared/code/scraperwiki.coffee
@@ -257,8 +257,10 @@ scraperwiki.reporting.message = (message, success, error) ->
   Send a message from the current user to Intercom, our reporting package
   ###
   dfd = new jQuery.Deferred()
-  dfd.done(success)
-  dfd.fail(error)
+  if typeof success is 'function'
+    dfd.done(success)
+  if typeof error is 'function'
+    dfd.fail(error)
 
   parent.scraperwiki.xdm.reportingMessage message, dfd.resolve, dfd.reject
   return dfd.promise()


### PR DESCRIPTION
…to scraperwiki.reporting.message()

Theoretically, the check inside of `parent.scraperwiki.xdm.reportingMessage()` isn't required if `scraperwiki.reporting.message()` behaves, but explicit is better than implicit.
