### PR TITLE
Increase size of Mongodb connection pool.

### DIFF
--- a/server/code/index.coffee
+++ b/server/code/index.coffee
@@ -51,6 +51,7 @@ if not process.env.CU_DB
 # Set up database connection
 mongoose.connect process.env.CU_DB,
   server:
+    poolSize: 200
     auto_reconnect: true
     socketOptions:
       keepAlive: 1


### PR DESCRIPTION
To avoid connection churn. It's a bit of a guess - everyone on the internet say "It depends".

Node defaults to 5, Python client defaults to 100. Maximum MongoDB supports is 20000. I've gone for 200.
