### PR TITLE
Track backbone routing actions in Optimizely

### DIFF
--- a/client/code/router/main.coffee
+++ b/client/code/router/main.coffee
@@ -53,7 +53,9 @@ class Cu.Router.Main extends Backbone.Router
 
   trackOptimizely: (e) ->
     window.optimizely = window.optimizely or []
-    window.optimizely.push ['trackEvent', 'helloOptimizely']
+    # 'activate' seems to send the current URL to Optimizely
+    # which is exactly what we want when pushState routing happens.
+    window.optimizely.push ['activate']
 
   trackIntercom: ->
     if 'real' of window.user and window.intercomUserHash != ''


### PR DESCRIPTION
Because, by default, Optimizely only listens on pageload.

Rather than using custom events, as Optimizely suggests, we've discovered the undocumented "activate" action sends the exact same XHR request as a native pageview, so we're using that instead. Hopefully it'll work.
