### PR TITLE
Change pool size to 20

### DIFF
--- a/server/code/index.coffee
+++ b/server/code/index.coffee
@@ -50,7 +50,7 @@ if not process.env.CU_DB
 # Set up database connection
 mongoose.connect process.env.CU_DB,
   server:
-    poolSize: 200
+    poolSize: 20
     auto_reconnect: true
     socketOptions:
       keepAlive: 1


### PR DESCRIPTION
This morning the server was down owing to connection failures to mongo.

We suspect a network issue, possibly exacerbated by having a large connection pool size. Shrinking it to 10 seemed to fix the problem so we're
going to try 20.
