### PR TITLE
Remove css .container transitions to make opening a dataset feel faster

### DIFF
--- a/shared/style/custard.css
+++ b/shared/style/custard.css
@@ -58,10 +58,6 @@ body.fullscreen .container {
   text-indent: -9000px;
   outline: none;
   background: transparent url(../image/header-logo.png) 0 11px no-repeat;
-  -moz-transition: margin-left 0.5s;
-  -webkit-transition: margin-left 0.5s;
-  -o-transition: margin-left 0.5s;
-  transition: margin-left 0.5s;
 }
 
 #logo:active {
@@ -77,10 +73,6 @@ body.fullscreen .container {
   position: absolute;
   top: 0;
   right: 0;
-  -moz-transition: right 0.5s;
-  -webkit-transition: right 0.5s;
-  -o-transition: right 0.5s;
-  transition: right 0.5s;
 }
 
 .fullscreen #header nav {

--- a/shared/style/scraperwiki.css
+++ b/shared/style/scraperwiki.css
@@ -707,10 +707,6 @@ input[type="color"],
 
 .container {
     width: 280px;
-    -moz-transition: width 0.5s;
-    -webkit-transition: width 0.5s;
-    -o-transition: width 0.5s;
-    transition: width 0.5s;
 }
 
 .navbar .container {


### PR DESCRIPTION
One for @frabcus.

I tried removing the `.container` class altogether (meaning that the nav bar, heading/subnav, and footer were full screen all the time) but it looked really bad on the `/datasets` and `/help/*` pages, where the page `#content` really still needed to be centred with a defined width.
