### PR TITLE
Add switch_url to Intercom

### DIFF
--- a/client/code/router/main.coffee
+++ b/client/code/router/main.coffee
@@ -139,6 +139,7 @@ class Cu.Router.Main extends Backbone.Router
               ts_datasets: 0
               tf_datasets: 0
               cb_datasets: 0
+              switch_url: "https://scraperwiki.com/switch/" + real.shortName
 
             _.each datasets, (dataset) ->
               date = moment(dataset.createdDate, 'YYYY-MM-DD HH:mm:ssZ').unix()


### PR DESCRIPTION
Intercom lets you click on URLs you send as user data.

So this lets you click straight from Intercom through to switching to that user (hopefully!)
