### PR TITLE
Switch from supervisor to nodemon

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -44,14 +44,10 @@ task 'test', 'Run unit tests', ->
   build -> test process.argv[3..]
 
 task 'dev', 'start dev env', ->
-  log 'Watching coffee files'
   process.env.NODE_ENV = 'testing'
-  supervisor = spawn 'node', ['./node_modules/supervisor/lib/cli-wrapper.js','-w','server/js,server/template,shared/js', '-e', 'js|html', 'server']
-  supervisor.stdout.pipe process.stdout
-  supervisor.stderr.pipe process.stderr
-  log 'Watching js files and running server'
-  build true, ->
-    # watch_js
+  nodemon = spawn 'nodemon', ['./server/code/index.coffee']
+  nodemon.stdout.pipe process.stdout
+  nodemon.stderr.pipe process.stderr
 
 Selenium = ->
   glob "selenium-server-standalone-2.*.jar", null, (err, files) ->

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "hiredis": "~0.1.15",
     "glob": "~3.2.6",
     "throttler-express": "git+https://github.com/scraperwiki/throttler-express.git",
-    "moment": "~2.6.0"
+    "moment": "~2.6.0",
+    "nodemon": "~1.0.17"
   },
   "scripts": {
     "install": "node_modules/coffee-script/bin/cake build",
@@ -49,7 +50,6 @@
     "mocha": "1.9.0",
     "mkdirp": "~0.3.4",
     "should": "~3.1.2",
-    "supervisor": "*",
     "sinon": "~1.9.1",
     "snockets": "~1.3.8",
     "backbone": "1.0.0",


### PR DESCRIPTION
This gives us coffeescript stack traces with the correct line numbers.

Woo.

(Oh, I'm running a more recent node which might have something to do with it,
but without this change it doesn't work).
