### PR TITLE
Remove nibbler

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "moment": "~2.6.0",
     "mongoose": "3.6.7",
     "morgan": "^1.0.1",
-    "nibbler": "git+https://github.com/mattrobenolt/node_nibbler.git",
     "nodealytics": "0.0.5",
     "nodemailer": "~0.3.43",
     "nodemon": "~1.0.17",

--- a/server/code/model/box.coffee
+++ b/server/code/model/box.coffee
@@ -1,7 +1,6 @@
 _ = require 'underscore'
 mongoose = require 'mongoose'
 async = require 'async'
-nibbler = require 'nibbler'
 request = require 'request'
 randtoken = require 'rand-token'
 
@@ -151,8 +150,7 @@ class Box extends ModelBase
         callback null, box
 
   @_generateBoxName: ->
-    r = Math.random() * Math.pow(10,9)
-    return nibbler.b32encode(String.fromCharCode(r>>24,(r>>16)&0xff,(r>>8)&0xff,r&0xff)).replace(/[=]/g,'').toLowerCase()
+    return randtoken.generate(7).toLowerCase()
 
   @generateUid: ->
     max = 429496729


### PR DESCRIPTION
This replaces a crazy little thing for generating the box names with a more
obvious "generate a random string".

Improvements
- We reuse `randtoken` which is now used elsewhere
- It's not crazy hard to reason about if you accept randtoken for what it is
- It uses the complete statespace of 36**7
- It doesn't pull in nibbler which requires npm install do git activity every time
