### PR TITLE
Remove 'cake build' during 'npm install'

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "xml2js": "~0.2.6"
   },
   "scripts": {
-    "install": "node_modules/coffee-script/bin/cake build",
     "start": ". ./activate && cake dev",
     "test": "bash -c '. ./activate && { redis-server & mocha test/unit ; }'"
   },


### PR DESCRIPTION
It isn't necessary anymore since we don't need to build coffee files into js
before we can execute them.
