### PR TITLE
Further cleaning to mocha wrapper

### DIFF
--- a/bin/mocha
+++ b/bin/mocha
@@ -13,17 +13,4 @@ then
   test/cleaner.coffee
 fi
 
-# Consider pushing to external program.
-eval last=\${$#}
-
-if [ "$#" = "0" ]
-then
-    env mocha ${@:1:$#-1} $(find test -name '*.coffee' | sort)
-else
-    if [ -d "$last" ]
-    then
-        env mocha ${@:1:$#-1} $(find "$last" -name '*.coffee' | sort)
-    else
-        env mocha $@
-    fi
-fi
+env mocha "$@"

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -3,3 +3,4 @@
 --compilers coffee:coffee-script/register
 --reporter spec
 --timeout 40000
+--recursive


### PR DESCRIPTION
Mocha gained a `--recursive` parameter, so we don't need to do a find 
anymore. Now the only thing left to figure out is how to run the cleaner,
then we can eliminate the wrapper entirely. It's ugly.

I'm thinking maybe we could add a --require to mocha.opts to do it, but I'm
not sure how to deal with the async.

Care to weigh in @drj11?
