### PR TITLE
require that CU_BOX_SERVER is on https

### DIFF
--- a/server/code/model/box.coffee
+++ b/server/code/model/box.coffee
@@ -91,7 +91,7 @@ class Box extends ModelBase
   @endpoint: (server, name) ->
     proto_server = "https://#{server}"
     if process.env.CU_BOX_SERVER
-      proto_server = "http://#{process.env.CU_BOX_SERVER}"
+      proto_server = "https://#{process.env.CU_BOX_SERVER}"
     return "#{proto_server}/#{name}"
 
   @findAllByUser: (shortName, callback) ->


### PR DESCRIPTION
Our new "cobalt-dev in docker" is served on HTTPS, so we need to change the URL we use when talking to cobalt-dev.
