### PR TITLE
Fix 'vender' typo

### DIFF
--- a/server/template/base_header.html
+++ b/server/template/base_header.html
@@ -27,7 +27,7 @@
     window.console = window.console || { log: function(){} }
   </script>
   <script src="/vendor/js/modernizr.custom.2.6.2.js"></script>
-  <script src="/vender/js/jquery.min.js"></script>
+  <script src="/vendor/js/jquery.min.js"></script>
   <script src="/vendor/js/bootstrap.min.js"></script>
 </head>
 <body>


### PR DESCRIPTION
I have no idea why this slipped through and didn't start causing me trouble
until many days after the change. Baffling.
