### PR TITLE
Upgrade mocha to 1.18.*

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "test": "bash -c '. ./activate && { redis-server & mocha test/unit ; }'"
   },
   "devDependencies": {
-    "mocha": "1.11.0",
+    "mocha": "~1.18.0",
     "mkdirp": "~0.3.4",
     "should": "~3.1.2",
     "sinon": "~1.9.1",


### PR DESCRIPTION
It has a fix for the problem of the before hook tearing down all remaining tests.

Remember to `npm install`!
