### PR TITLE
Use production-activate in cron job

### DIFF
--- a/cron/delete-datasets.sh
+++ b/cron/delete-datasets.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 export $(grep CU_DB /etc/init/custard.conf)
 export $(grep CU_BOX_SERVER /etc/init/custard.conf)


### PR DESCRIPTION
To use the new production-activate script to start cron job.
