### PR TITLE
Revert "Merge pull request #635 from scraperwiki/disable-broken-test"

### DIFF
--- a/test/integration/tool_rpc.coffee
+++ b/test/integration/tool_rpc.coffee
@@ -142,7 +142,7 @@ describe 'Tool RPC', ->
           text.should.not.be.empty
           done()
 
-      xit 'returns the correct tables', (done) ->
+      it 'returns the correct tables', (done) ->
         wd40.getText '#sqlMetaDataText', (err, text) =>
           obj = JSON.parse text
           should.exist obj?.table?.SurLeTable


### PR DESCRIPTION
This reverts commit b2e43de43329ecaeaec12505e78f6145662235c5, reversing 
changes made to 7255e427dbe459c42827698409a93f4ead50c1da.

This reverses #635.

Here is the broken test:

https://github.com/scraperwiki/custard/blob/disable-broken-test/test/integration/tool_rpc.coffee#L153

``` coffee
      xit 'returns the correct tables', (done) ->
        wd40.getText '#sqlMetaDataText', (err, text) =>
          obj = JSON.parse text
          should.exist obj?.table?.SurLeTable
          should.exist obj?.table?.VoirLeLapin
          done()
```

It appears to expect that the metadata contain SurLeTable and VoirLeLapin.

https://github.com/scraperwiki/test-app-tool/blob/6fc4f600165a75150fcc23515599f09c2de8e749/http/index.html#L63

For some reason this doesn't work.

To investigate.
