### PR TITLE
Improve behaviour if there is a selenium error

### DIFF
--- a/test/integration/setup_teardown.coffee
+++ b/test/integration/setup_teardown.coffee
@@ -14,7 +14,10 @@ before (done) ->
         cleaner.clear_and_set_fixtures ->
           cb()
       (cb) ->
-        wd40.init ->
+        wd40.init (err) ->
+          if err
+            cb new Error("wd40 init error: #{err} -- is your Selenium server running?")
+            return
           browser.get base_url, ->
             cb()
     ], done


### PR DESCRIPTION
Old behaviour: tests would all try to run and fail because selenium was
broken.

New behaviour: beforeall hook fails correctly and we get just one error
telling us the problem.
