### PR TITLE
Remove spurious exports from cron job

### DIFF
--- a/cron/delete-datasets.sh
+++ b/cron/delete-datasets.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
 
-export $(grep CU_DB /etc/init/custard.conf)
-export $(grep CU_BOX_SERVER /etc/init/custard.conf)
-
 source /etc/custard/production-activate
 /opt/custard/bin/clean_crontabs.coffee


### PR DESCRIPTION
Bug fix: the cron job was printing the environment
