### PR TITLE
Update wd40 to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "backbone-relational": "~0.8.0",
     "jsdom": "~0.10.1",
     "wd": "~0.2.21",
-    "wd40": "*",
+    "wd40": "~0.1.0",
     "mongodb": "~1.2.12",
     "sqlite3": "~2.1.7",
     "supertest": "~0.7.1"


### PR DESCRIPTION
Previously the version specification was "*", which probably makes sense in
that we control wd40, so if we're updating it, it's probably because we want
to use it. OTOH, I want to actually document in the custard repository when
wd40 is changed in an important way.

I've published it to NPM.

Since this only changes a development dependency it can be merged without prejudice.
