### PR TITLE
Category and position options for tools

### DIFF
--- a/client/code/model/tool.coffee
+++ b/client/code/model/tool.coffee
@@ -31,7 +31,7 @@ class Cu.Collection.Tools extends Backbone.Collection
     new Cu.Collection.Tools basics
 
   comparator: (model) ->
-    model.get('manifest')?.displayName
+    model.get('manifest')?.position
 
   findByName: (toolName) ->
     @find (tool) -> tool.get('name') is toolName

--- a/client/code/model/tool.coffee
+++ b/client/code/model/tool.coffee
@@ -31,7 +31,7 @@ class Cu.Collection.Tools extends Backbone.Collection
     new Cu.Collection.Tools basics
 
   comparator: (model) ->
-    model.get('manifest')?.position
+    model.get('manifest')?.position || 9999
 
   findByName: (toolName) ->
     @find (tool) -> tool.get('name') is toolName

--- a/client/code/view/tool/list.coffee
+++ b/client/code/view/tool/list.coffee
@@ -23,26 +23,36 @@ class Cu.View.ToolList extends Backbone.View
     @$el.hide().append('<span class="close">&times;</span>')
     headerView = new Cu.View.ToolListHeader {type: @options.type}
     @$el.append headerView.render().el
-    @row = $('<div class="row">').appendTo @$el
-    @row.wrap('<div class="container">')
+    @container = $('<div class="container">').appendTo @$el
     @addTools() if app.tools().length
     @$el.fadeIn 200
     return this
 
   addTools: ->
     @$el.remove('.tool')
-    app.tools().each @addTool
+    categories = _.groupBy app.tools().toArray(), (tool) ->
+      tool.get('manifest')?.category || "Other"
 
-  addTool: (tool) =>
+    for category, tools of categories
+      console.log "category:", category, tools
+      @addToolCategory category, tools
+
+  addToolCategory: (category, tools) =>
+    $('<h3>' + category + '</h3>').appendTo @container
+    row = $('<div class="row">').appendTo @container
+    for tool in tools
+      @addTool row, tool
+
+  addTool: (row, tool) =>
     if @options.type is 'importers' and tool.get('type') is 'importer'
       view = new Cu.View.AppTile model: tool
       view.on 'install:failed', =>
         @closeChooser false
       , @
-      @row.append view.render().el
+      row.append view.render().el
     else if @options.type isnt 'importers' and tool.get('type') isnt 'importer'
       view = new Cu.View.PluginTile { model: tool, dataset: @options.dataset }
-      @row.append view.render().el
+      row.append view.render().el
 
   closeChooser: (navigate=true) ->
     @$el.fadeOut 200, =>

--- a/fixtures.js
+++ b/fixtures.js
@@ -214,6 +214,7 @@ exports.tools = [{
   gitUrl: "https://github.com/scraperwiki/newdataset-tool.git",
   manifest: {
     description: "Create a new, empty dataset",
+    position: 10,
     displayName: "Code a dataset!",
     category: "Programming",
     color: "#555",
@@ -226,6 +227,7 @@ exports.tools = [{
   gitUrl: "https://github.com/scraperwiki/test-app-tool.git",
   manifest: {
     description: "Test app",
+    position: 1,
     displayName: "Test app",
     color: "#b0df18",
     icon: "https://s3-eu-west-1.amazonaws.com/sw-icons/tool-icon-test.png"
@@ -248,6 +250,7 @@ exports.tools = [{
   gitUrl: "https://github.com/scraperwiki/test-push-tool.git",
   manifest: {
     description: "Test push",
+    position: 2,
     displayName: "Test push",
     color: "#b0df18",
     icon: "https://s3-eu-west-1.amazonaws.com/sw-icons/tool-icon-test.png"
@@ -300,7 +303,9 @@ exports.tools = [{
   gitUrl: "git://github.com/scraperwiki/spreadsheet-upload-tool.git",
   manifest: {
     description: "Upload an Excel file or CSV",
+    position: 5,
     displayName: "Upload a spreadsheet",
+    category: "Spreadsheets",
     color: "#029745",
     icon: "https://s3-eu-west-1.amazonaws.com/sw-icons/tool-icon-spreadsheet-upload.png"
   }

--- a/fixtures.js
+++ b/fixtures.js
@@ -215,6 +215,7 @@ exports.tools = [{
   manifest: {
     description: "Create a new, empty dataset",
     displayName: "Code a dataset!",
+    category: "Programming",
     color: "#555",
     icon: "https://s3-eu-west-1.amazonaws.com/sw-icons/tool-icon-code.png"
   }


### PR DESCRIPTION
You can set "category" in the manifest of a tool to add headings. You can sort
the order, both of the categories and things in them, using a second "position"
attribute also in the manifest.

Defaults to "category" of "Other".

Before deploying, I'd like to test it in Optimizely, which is waiting for some
nearby experiments to complete first.