### PR TITLE
Automatically expire plans

### DIFF
--- a/bin/find-unsubscribed.coffee
+++ b/bin/find-unsubscribed.coffee
@@ -49,7 +49,14 @@ main = (TheUser) ->
         else if subscription
           console.log "    subscription:", subscription.plan.plan_code
         else
-          console.log "    no subscription"
+          console.log "    no subscription - changing to free-trial"
+          user.accountLevel = 'free-trial'
+          user.planExpires = undefined
+          user.save (err, newUser) ->
+            if err?
+              console.log "    ERROR saving user", err
+            else
+              console.log "    YEP updated user"
         cb null
     , (err) ->
       process.exit() if CLI?


### PR DESCRIPTION
I've been doing this by hand for a few months, so I think it is reliable.
Would like a code review!

To deploy, it requires a change to `salt/custard/init.sls` to set 
`export CU_DB={{pillar.mongo.url}}` (i.e. no longer readonly)
for `/usr/local/bin/scraperwiki-find-unsubscribed.sh`

Is that change reasonable?
