### PR TITLE
Corporate signups only

### DIFF
--- a/client/template/help-whats-new.eco
+++ b/client/template/help-whats-new.eco
@@ -5,7 +5,7 @@
   Here&rsquo;s a sixty-second rundown of how it works.</p>
   <p style="margin-bottom: 0">
     <a class="btn btn-large" data-nonpushstate href="/help/" style="margin-right: 20px;">Read the docs</a>
-    <a class="btn btn-primary btn-large" data-nonpushstate href="/pricing">Sign up <i class="icon-chevron-right"></i></a>
+    <a class="btn btn-primary btn-large" data-nonpushstate href="/login">Log in<i class="icon-chevron-right"></i></a>
   </p>
 </div>
 

--- a/client/template/nav.eco
+++ b/client/template/nav.eco
@@ -54,7 +54,6 @@
 <li class="help"><a href="/contact" data-nonpushstate id="intercomButton" class="btn btn-danger">Help</a></li>
 <% else: %>
 <li class="login"><a href="/login" data-nonpushstate>Log in</a></li>
-<li class="pricing"><a href="/pricing">Sign up</a></li>
 <li class="docs"><a href="/help">Help</a></li>
 <% end %>
 </ul>

--- a/client/template/pricing.eco
+++ b/client/template/pricing.eco
@@ -33,6 +33,7 @@
 </div>
 -->
 
+<!--
 <div class="plan datascientist account-large swcol<% if @upgrade is 'upgrade': %> glowing<% end %>">
   <h2>Data Scientist</h2>
   <p class="cost">$29<small>/mth</small></p>
@@ -89,13 +90,19 @@
   </ul>
 </div>
 
-<div class="clearfix"></div>
+-->
+
+<!-- <div class="clearfix"></div>
 
 <p class="alert alert-error"><i class="icon-warning-sign"></i> Sorry, the <strong>twitter tools are not available!</strong> Please <i class="icon-hand-right"></i> <a href="https://blog.scraperwiki.com/2014/08/the-story-of-getting-twitter-data-and-its-missing-middle/">see our blog post</a> for more information.</a></p>
 
-<p class="corporate">We also offer Enterprise data hubs with professional services at prices from $1000 / month. 
+--> 
+
+<p class="corporate">We offer Enterprise data hubs with professional services at prices from $2000 / month. 
 For more information read our <a href="https://scraperwiki.com/help/corporate/">Corporate FAQ</a>,
 and if you are interested <a href="https://scraperwiki.com/professional#request">get in touch</a> with our professional services team.
 </p>
+
+
 
 

--- a/server/code/index.coffee
+++ b/server/code/index.coffee
@@ -617,7 +617,8 @@ app.get '/subscribe/?*', renderClientApp
 app.get '/thankyou/?*', renderClientApp
 
 app.get '/pricing/?*', (req, resp) ->
-  resp.redirect '/signup/freetrial'
+  resp.redirect '/login'
+#renderServerAndClientSide page: 'pricing', req, resp
 
 app.get '/signup/community', (req, resp) ->
   resp.redirect '/signup/freetrial'

--- a/server/code/index.coffee
+++ b/server/code/index.coffee
@@ -617,8 +617,7 @@ app.get '/subscribe/?*', renderClientApp
 app.get '/thankyou/?*', renderClientApp
 
 app.get '/pricing/?*', (req, resp) ->
-  resp.redirect '/login'
-#renderServerAndClientSide page: 'pricing', req, resp
+  renderServerAndClientSide page: 'pricing', req, resp
 
 app.get '/signup/community', (req, resp) ->
   resp.redirect '/signup/freetrial'

--- a/server/code/index.coffee
+++ b/server/code/index.coffee
@@ -617,7 +617,7 @@ app.get '/subscribe/?*', renderClientApp
 app.get '/thankyou/?*', renderClientApp
 
 app.get '/pricing/?*', (req, resp) ->
-  renderServerAndClientSide page: 'pricing', req, resp
+  resp.redirect '/signup/freetrial'
 
 app.get '/signup/community', (req, resp) ->
   resp.redirect '/signup/freetrial'

--- a/server/code/model/user.coffee
+++ b/server/code/model/user.coffee
@@ -55,7 +55,7 @@ requestRecurlyAPI = (path, callback) ->
     if err?
       return callback err, null
     else if recurlyResp.statusCode is 404
-      return callback { error: "You have no Recurly account. Sign up for a paid plan at http://scraperwiki.com/pricing" }, null
+      return callback { error: "You have no Recurly account." }, null
     else if recurlyResp.statusCode isnt 200
       return callback { statusCode: recurlyResp.statusCode, error: recurlyResp.body }, null
 
@@ -118,7 +118,7 @@ class exports.User extends ModelBase
         return callback err, null
 
       if not obj.subscriptions
-        return callback { error: "You do not have a paid subscription. Sign up at http://scraperwiki.com/pricing" }, null
+        return callback { error: "You do not have a paid subscription." }, null
 
       # xml2js converts multiple entities within entities as an array,
       # but a single one is a single object. So we wrap into a list where necessary.

--- a/server/template/base_header.html
+++ b/server/template/base_header.html
@@ -40,7 +40,6 @@
       <nav>
         <ul>
           <li class="login"><a href="/login">Log in</a></li>
-          <li class="pricing"><a href="/pricing">Sign up</a></li>
           <li class="docs"><a href="/help">Help</a></li>
         </ul>
       </nav>

--- a/server/template/login.html
+++ b/server/template/login.html
@@ -25,9 +25,13 @@
             <button type="submit" id="login" class="btn btn-primary">
               <i class="icon-ok space"></i> Log In
             </button>
-            <a class="btn btn-link" href="/pricing/">or Sign up</a>
             <!-- preload the spinner icon by hiding it off screen -->
             <img src="/image/loader-btn-primary.gif" width="16" height="16" style="position: absolute; left: -4000px;">
+          </p>
+
+          <p>
+            New accounts are made as part of larger projects, please
+            <a href="/contact/">contact us</a> for information.
           </p>
         </form>
 

--- a/server/template/login.html
+++ b/server/template/login.html
@@ -29,10 +29,14 @@
             <img src="/image/loader-btn-primary.gif" width="16" height="16" style="position: absolute; left: -4000px;">
           </p>
 
-          <p>
-            New accounts are made as part of larger projects, please
-            <a href="/contact/">contact us</a> for information.
+          <h2>Get a new account</h2>
+
+          <p class="corporate">We offer Enterprise data hubs with professional services at prices from $2000 / month.</p>
+
+          <p>For more information read our <a href="https://scraperwiki.com/help/corporate/">Corporate FAQ</a>,
+          and if you are interested <a href="https://scraperwiki.com/professional#request">get in touch</a> with our professional services team.
           </p>
+
         </form>
 
     </div>


### PR DESCRIPTION
Remove signup page, redirect to login. On login and pricing page, say we only
sell Enterprise data hubs from $2000 / month upwards.

When deployed, needs changes to marketing pages on WordPress site:
* [ ] Remove code in your browser page
* [ ] Remove "Code a scraper" on front page
* [ ] Edit what we are summary on front page
* [ ] Maybe add a page on data baker
* [ ] Remove "platform pricing" menu option.
* [ ] Update journalism page telling how to get a/c
