### PR TITLE
Disable self service signup

### DIFF
--- a/server/code/index.coffee
+++ b/server/code/index.coffee
@@ -623,7 +623,9 @@ app.get '/signup/community', (req, resp) ->
   resp.redirect '/signup/freetrial'
 
 app.get '/signup/?*', (req, resp) ->
-  renderServerAndClientSide {page: "sign-up", subnav: 'signupnav'}, req, resp
+  # disable self service signup
+  resp.redirect 'https://scraperwiki.com/products/scraping-platform'
+  #renderServerAndClientSide {page: "sign-up", subnav: 'signupnav'}, req, resp
 
 app.get '/help/?:section', (req, resp) ->
   req.params.section ?= 'home'


### PR DESCRIPTION
This completely disables it.

We can only make new accounts using "Create Profile" form now. https://scraperwiki.com/create-profile

Mainly to cover Google linking to the Explorer page.

Also simplifies what we have to do for Journalists (no access to Compose.io needed any more for new accounts).